### PR TITLE
Smooth out development environment setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ eggs/
 *.egg
 TODO.md
 spot/benchmarks/*/workload.json
+
+spot-env/

--- a/README.md
+++ b/README.md
@@ -3,15 +3,30 @@ Created by Capstone Group 59
 
 ## Setup
 
-- Clone the repository
-- Change your current directory to the root directory of the repository
-- Install the repository as a package
+### Requirements
+- Python 3
+- AWS CLI (configured with `aws configure`)
+- MongoDB (by default, accessible on `localhost:27017`)
 
-  ```bash
-  pip install -e .
-  ```
-- Run spot/main.py
+### Steps
+1. Create and activate a virtualenv.
+```bash
+python3 -m venv spot-env
+source spot-env/bin/activate
+```
 
-  ```bash
-  python3 spot/main.py
-  ```
+2. Install required packages.
+```
+pip install -r requirements.txt
+```
+
+3. Install SPOT as an editable package.
+```bash
+pip install -e .
+```
+
+4. Run it!
+```bash
+spot
+```
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+pandas==1.4.0
+pymongo==4.0.1
+matplotlib==3.5.1
+requests==2.27.1
+requests_futures==1.0.0
+boto3==1.20.44
+sklearn

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,9 @@ setup(name='spot',
       },
       install_requires=[],
       extras_require={},
+      entry_points={
+          'console_scripts': ['spot=spot.main:main']
+          },
       description='Serverless Price Optimization Tool',
       version='0.0.1'
       )


### PR DESCRIPTION
Dependencies and setup tasks are listed explicitly in README.md, and
installing requirements is simplified to one command. I also made the
whole package runnable as
```
$ spot
```
but that's mostly for convenience - when we're building a more
fleshed-out CLI, we'll probably want to clean up the package structure a
bit and change the entry point from main to a specific CLI script.