### PR TITLE
use folder name for plot path instead of function name

### DIFF
--- a/spot/Spot.py
+++ b/spot/Spot.py
@@ -23,9 +23,9 @@ class Spot:
                 json.dump(self.config["workload"], json_file)
 
         try:
-            benchmark_dir = self.config["folder_name"]
+            self.benchmark_dir = self.config["folder_name"]
         except KeyError:
-            benchmark_dir = None
+            self.benchmark_dir = self.config["function_name"]
 
         # Instantiate SPOT system components
         self.price_retriever = AWSPriceRetriever(
@@ -52,7 +52,7 @@ class Spot:
             self.config["DB_URL"],
             self.config["DB_PORT"],
             self.config["last_log_timestamp"],
-            benchmark_dir,
+            self.benchmark_dir,
         )  # TODO: Parametrize ML model constructor with factory method
         self.DBClient = DBClient(self.config["DB_URL"], self.config["DB_PORT"])
 
@@ -76,7 +76,7 @@ class Spot:
         # Save model predictions to db for error calculation
         # self.DBClient.add_document_to_collection(self.config["function_name"], "memory_predictions", memory_predictions)
 
-        plotter = Plot(self.config["function_name"], self.DBClient)
+        plotter = Plot(self.config["function_name"], self.DBClient, self.benchmark_dir)
         plotter.plot_config_vs_epoch()
 
     def execute(self):

--- a/spot/visualize/Plot.py
+++ b/spot/visualize/Plot.py
@@ -8,9 +8,10 @@ from spot.db.db import DBClient
 
 
 class Plot:
-    def __init__(self, function_name, DBClient):
+    def __init__(self, function_name, DBClient, folder_name):
         self.function_name = function_name
         self.DBClient = DBClient
+        self.folder_name = folder_name
 
     def __fetch_config_vs_epoch_data(self):
         # gets all past configs associated with the current function name
@@ -47,7 +48,7 @@ class Plot:
         timestamp = today.strftime("%Y-%m-%dT%H:%M:%S.%f+0000")
         plt.savefig(
             "spot/benchmarks/"
-            + self.function_name
+            + self.folder_name
             + "/"
             + self.function_name
             + "-"


### PR DESCRIPTION
Visualization throws an error for benchmarks with a folder name different than the function name. Pass user-defined folder name to Plot class for the path to save the plot.