### PR TITLE
Refactor timestamp logic

### DIFF
--- a/spot/configs/aws_config_retriever.py
+++ b/spot/configs/aws_config_retriever.py
@@ -13,11 +13,13 @@ class AWSConfigRetriever:
     def get_latest_config(self):
         client = boto3.client("lambda")
         config = client.get_function_configuration(FunctionName=self.function_name)
-        date = datetime.datetime.strptime(
-            config["LastModified"], "%Y-%m-%dT%H:%M:%S.%f+0000"
+
+        last_modified = datetime.datetime.strptime(
+            config["LastModified"], "%Y-%m-%dT%H:%M:%S.%f%z"
         )
-        timestamp = str((date - datetime.datetime(1970, 1, 1)).total_seconds() * 1000)
-        config["LastModifiedInMs"] = int(timestamp[:-2])
+        last_modified_ms = int(last_modified.timestamp() * 1000)
+        config["LastModifiedInMs"] = str(last_modified_ms)
+
         config["Architectures"] = config["Architectures"][0]
         self.DBClient.add_new_config_if_changed(self.function_name, "config", config)
 

--- a/tests/config_tests/test_config_retriever.py
+++ b/tests/config_tests/test_config_retriever.py
@@ -29,13 +29,12 @@ class TestConfigRetrieval(unittest.TestCase):
             self.configRetriever.get_latest_config()
 
             # assert a database call has been made with function add_new_config_if_changed with appropriate variables
-            date = datetime.datetime.strptime(
-                sample_config["LastModified"], "%Y-%m-%dT%H:%M:%S.%f+0000"
+            last_modified = datetime.datetime.strptime(
+                sample_config["LastModified"], "%Y-%m-%dT%H:%M:%S.%f%z"
             )
-            timestamp = str(
-                (date - datetime.datetime(1970, 1, 1)).total_seconds() * 1000
-            )
-            sample_config["LastModifiedInMs"] = int(timestamp[:-2])
+            last_modified_ms = int(last_modified.timestamp() * 1000)
+            sample_config["LastModifiedInMs"] = str(last_modified_ms)
+
             sample_config["Architectures"] = sample_config["Architectures"][0]
             callTemp = call(self.function, "config", sample_config)
             mockDBClient.assert_has_calls([callTemp])


### PR DESCRIPTION
The timestamp logic was confusing, and the use of string slicing for truncating to an integer was potentially fragile. This simplifies it a bit and resolves #42.