### PR TITLE
Logs fields are saved as int or float instead of text

### DIFF
--- a/spot/logs/aws_log_retriever.py
+++ b/spot/logs/aws_log_retriever.py
@@ -39,9 +39,9 @@ class AWSLogRetriever:
                     for message_section in message_sections[1:-1]:
                         field_name = message_section.split(":")[0]
                         value = message_section.split(":")[1][1:].split(" ")[0]
-                        if re.match(r'^[0-9]+\.[0-9]+$', value):
+                        if re.match(r"^[0-9]+\.[0-9]+$", value):
                             log[field_name] = float(value)
-                        elif re.match(r'^[0-9]+$', value):
+                        elif re.match(r"^[0-9]+$", value):
                             log[field_name] = int(value)
                         else:
                             log[field_name] = value

--- a/tests/log_test/test_aws_log_retriever.py
+++ b/tests/log_test/test_aws_log_retriever.py
@@ -60,7 +60,7 @@ class TestLogRetrival(unittest.TestCase):
             "Billed Duration": 2,
             "Memory Size": 128,
             "Max Memory Used": 39,
-            "Init Duration": 113.44
+            "Init Duration": 113.44,
         }
 
         for s in stream["logStreams"]:


### PR DESCRIPTION
In the MongoDB database, save the log files as int and float instead of text. This is useful for querying the collections