### PR TITLE
wait for the lambda to be updated when changing memory

### DIFF
--- a/spot/invocation/aws_lambda_invoker.py
+++ b/spot/invocation/aws_lambda_invoker.py
@@ -75,8 +75,8 @@ class AWSLambdaInvoker:
         self.client.update_function_configuration(
             FunctionName=self.lambda_name, MemorySize=memory_mb
         )
-        # FIXME: properly handle memory change
-        time.sleep(5)
+        waiter = self.client.get_waiter("function_updated")
+        waiter.wait(FunctionName=self.lambda_name)
 
 
 class LambdaInvocationError(Exception):


### PR DESCRIPTION
Resolves #95 
Looks like boto3 already had the api. Didn't even need to publish & specify a version.