### PR TITLE
fix: added grpcio-status to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ google-cloud-functions~=1.13.0
 google-cloud-billing~=1.11.1
 google-cloud-logging~=3.5.0
 google-api-core~=2.11.1
+grpcio-status~=1.59.2
 numpy~=1.23.4
 scipy~=1.9.3
 jsonschema~=4.18.0


### PR DESCRIPTION
Fixes running Parrotfish on Python 3.8 ( fix for #161 )